### PR TITLE
add support for track_total_hits

### DIFF
--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -75,6 +75,7 @@ def load_conf(args, defaults=None, overwrites=None):
     conf.setdefault('max_query_size', 10000)
     conf.setdefault('scroll_keepalive', '30s')
     conf.setdefault('max_scrolling_count', 990) # Avoid stack overflow in run_query, note that 1000 is Python's stack limit
+    conf.setdefault('track_total_hits', False)
     conf.setdefault('disable_rules_on_error', True)
     conf.setdefault('scan_subdirectories', True)
     conf.setdefault('rules_loader', 'file')

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -130,6 +130,7 @@ class ElastAlerter(object):
 
         self.max_query_size = self.conf['max_query_size']
         self.scroll_keepalive = self.conf['scroll_keepalive']
+        self.track_total_hits = self.conf['track_total_hits']
         self.writeback_index = self.conf['writeback_index']
         self.run_every = self.conf['run_every']
         self.alert_time_limit = self.conf['alert_time_limit']
@@ -524,9 +525,11 @@ class ElastAlerter(object):
         )
         if term_size is None:
             term_size = rule.get('terms_size', 50)
+        
+        track_total_hits = rule.get('track_total_hits', self.track_total_hits)
         query = self.get_aggregation_query(base_query, rule, query_key, term_size, rule['timestamp_field'])
         try:
-            res = self.thread_data.current_es.search(index=index, body=query, size=0, ignore_unavailable=True)
+            res = self.thread_data.current_es.search(index=index, body=query, size=0, track_total_hits=track_total_hits, ignore_unavailable=True)
         except ElasticsearchException as e:
             if len(str(e)) > 1024:
                 e = str(e)[:1024] + '... (%d characters removed)' % (len(str(e)) - 1024)


### PR DESCRIPTION
## Description
In ES v7+, add support for track_total_hits to fix aggretation queries to allow more than 10000 hits.
<!--
-->

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [x] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [x] I have manually tested all relevant modes of the change in this PR.
- [x] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->
